### PR TITLE
Output redirects

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -27,13 +27,17 @@ else
 fi
 
 # Helper functions
+indent_output() {
+  while read -r data; do
+    printf " ${color}|${reset}  %s\n" "$data"
+  done
+}
+
 pretty_output() {
   if [ -n "$verbose" ]; then
-    while read -r data; do
-      printf " ${color}|${reset}  %s\n" "$data"
-    done
+    indent_output
   else
-    cat >/dev/null 2>&1
+    cat >/dev/null
   fi
 }
 
@@ -45,9 +49,13 @@ print_colored() {
 
 git() {
   if [ -n "$noop" ]; then
-    echo git "$@"
+    echo git "$@" | indent_output
+  elif [ -n "$quiet" ]; then
+    command git "$@" &>/dev/null
+  elif [ -n "$verbose" ]; then
+    command git "$@" 2>&1 | indent_output
   else
-    command git "$@" 2>&1 | pretty_output
+    command git "$@" 2>&1 >/dev/null | indent_output
   fi
 }
 
@@ -58,7 +66,7 @@ is_rbenv_git_repo() {
 rbenv_update() {
   if is_rbenv_git_repo; then
     print_colored "Updating $1"
-    git pull --no-rebase --ff 2>&1
+    git pull --no-rebase --ff
   else
     print_colored "Skipping $1 since it's not an rbenv git repo"
   fi

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -33,14 +33,6 @@ indent_output() {
   done
 }
 
-pretty_output() {
-  if [ -n "$verbose" ]; then
-    indent_output
-  else
-    cat >/dev/null
-  fi
-}
-
 print_colored() {
   if [ -z "$quiet" ]; then
     printf "${color}%s${reset}\n" "$1"
@@ -49,12 +41,16 @@ print_colored() {
 
 git() {
   if [ -n "$noop" ]; then
+    # print would-be command
     echo git "$@" | indent_output
   elif [ -n "$quiet" ]; then
+    # mute stdout and stderr
     command git "$@" &>/dev/null
   elif [ -n "$verbose" ]; then
+    # indent stdout and stderr
     command git "$@" 2>&1 | indent_output
   else
+    # mute stdout, indent stderr
     command git "$@" 2>&1 >/dev/null | indent_output
   fi
 }


### PR DESCRIPTION
This does finer-grained output redirection, and ensures everything is properly indented.

--noop: prints the to-be executed command, indented
--quiet: mutes both stdout and stderr from git
--verbose: prints both stderr and stdout from git, indenting both
default: mutes stdout from git, prints stderr, indented

This way, by default, any stderr messages from git are still printed and indented. --quiet mutes everything, and --verbose prints everything

Opening as a second-level PR so that we can review the main PR as a whole.
